### PR TITLE
Update the usage of codeclimate-test-reporter gem

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
-require 'codeclimate-test-reporter'
-CodeClimate::TestReporter.start
+require 'simplecov'
+SimpleCov.start
 
 require 'moodle/api'
 require 'vcr'


### PR DESCRIPTION
Update spec_helper to require simplecov instead of codeclimate-test-reporter as this usage has been deprecated. 

See https://github.com/codeclimate/ruby-test-reporter/blob/master/CHANGELOG.md#v100-2016-11-03
