### PR TITLE
updated rake dependency

### DIFF
--- a/lib/moodle/api/version.rb
+++ b/lib/moodle/api/version.rb
@@ -3,6 +3,6 @@ module Moodle
   # Semantic versioning is used
   # http://guides.rubygems.org/patterns/#semantic-versioning
   module Api
-    VERSION = '1.5'
+    VERSION = '1.6'.freeze
   end
 end

--- a/moodle-api.gemspec
+++ b/moodle-api.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler', '~> 1.9'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake', '~> 12.3.3'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'guard-rspec'
   spec.add_development_dependency 'rubocop'


### PR DESCRIPTION
Rake dependencies before 12.3.3 has security vulnerabilities. Updated the rake version and bumped the gem version